### PR TITLE
Move community files from `withastro/astro`

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+All complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+See [GOVERNANCE.md](GOVERNANCE.md#Moderation) for instructions on reporting a Code of Conduct violation and a full description of the review process.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/COMMUNITY_GUIDE.md
+++ b/COMMUNITY_GUIDE.md
@@ -1,0 +1,44 @@
+### Guide to Contributing to the Astro Community
+
+When interacting, strive to maintain a friendly, empathetic tone. This includes, but is not limited to, interactions on Discord, GitHub, and Twitter.
+
+"Tone" refers to word, punctuation, and conversational choices that determine how your message _feels_ to others. This includes nonverbal cues, like emojis and gifs.
+
+Compare these two responses:
+
+_Question:_ Hey, I'm beginning with Astro. I tried to use `document` in my Astro page, but it says that the object doesn't exist. How can I manipulate the DOM?
+
+| Answer 1                                                                           | Answer 2                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| You can't manipulate the DOM from an Astro file 😂 Astro is a static site builder. | Hey, welcome to the community! <br/> Astro pages and components run on the server. Because of that, you won't have access to everything you're used to when writing JavaScript for the web. You're on the right track, though - you can access `document` from a `<script>` tag in your Astro file. <br/> Check out the docs here, and let me know if you need any more help! https://docs.astro.build/en/core-concepts/astro-components/#client-side-scripts |
+
+Answer 2 centered the user's feelings and as such, took more effort. However, it made a significant difference. This response:
+
+- welcomed the new member into the community
+- made them feel validated for asking the question ("You're on the right track")
+- provided an explanation that fit the person who asked the question: _Answer 2_ sought to explain things to a self-described beginner, who might not understand the implications of "static site builder"
+- made it clear that the community is willing to help and that asking is not a burden ("let me know if you need any more help!")
+- equipped them with a next step ("Check out the docs here"), while at the same time familiarized them onto our docs page
+
+Our community prides itself on being _positive_, _helpful_, and _inclusive_. If you have these goals in mind when interacting in the community, you're on the right track!
+
+- To stay positive:
+
+  - Make it clear that you appreciate the other person's contributions.
+  - Aim to learn: even complaints can be valuable feedback.
+  - Look for alternate interpretations of your message before sending, and consider clarifying your intent if you're unsure how your words might come across (using exclamation points and emojis to convey friendliness is generally 👍 !)
+  - During conflict: maintain respect, avoid aggression, and avoid making it personal ("you").
+  - Set boundaries. Feel free to step away from a conversation when you feel frustrated. Reach out to community leaders who can step in and de-escalate the situation. We are in this together!
+
+- To stay helpful:
+
+  - Seek to understand the the other person's desired outcomes. Are they looking for assistance? Just wanting to vent?
+  - When explaining something, first establish the knowledge level of the person you're responding to. Match your explanation to that level. A good rule of thumb is to assume that everyone is a beginner. Your response will most likely be read by others as well!
+  - Ask clarifying questions. If you're not sure what the person meant, ask them if your understanding is correct. If you're not sure what they already know, ask them if they're familiar with a concept.
+
+- To stay inclusive:
+
+  - Refer to someone by their expressed name. Don't use your own nicknames for someone (unless you're friends with established trust).
+  - Refer to someone by their expressed pronouns. If this wasn't expressed, use [`they/them`](http://pronoun.is/they/them), which in English can be used to refer to individuals of any gender.
+  - If you sense hesitancy in someone's participation, make it clear that you're happy they're participating.
+  - Advocate for someone if you see that they're being dismissed.

--- a/FUNDING.md
+++ b/FUNDING.md
@@ -1,0 +1,40 @@
+# Astro Project Funding
+
+_Last Updated: 02-09-2022_
+
+## Raising Funds
+
+Astro is an MIT licensed open source project and completely free to use. However, the amount of effort needed to maintain and develop new features for Astro is not sustainable without proper financial backing. We need your help to achieve this.
+
+Learn more about sponsorship on our [Open Collective.](https://opencollective.com/astrodotbuild).
+
+### Why Open Collective?
+
+- **Full Transparency.** Everyone gets to see where money is coming from and where it's going.
+- **Individual and Corporate Sponsors.** Open Collective makes it easy for both individuals and companies to sponsor open source projects.
+- **Potential Tax Benefits.** Because funds are paid to the Open Source Collective, a 501(c)(6) organization in the U.S., there may be tax benefits for some donors (please check with your accountant).
+- **Automatic Invoicing.** For corporate sponsors, Open Collective automatically generates and sends invoices for tracking purposes.
+- **Open Participation.** Anyone can request reimbursement for funds spent helping the Astro project and Astro can pay out to anyone.
+
+_List borrowed from [ESLint: "Funding ESLint's Future."](https://eslint.org/blog/2019/02/funding-eslint-future)_
+
+## Distributing Funds
+
+100% of money raised is invested back into the community. Every dollar spent **must** support and/or improve Astro in some way.
+
+See all past expenses on our [Open Collective.](https://opencollective.com/astrodotbuild)
+
+Below is a (non-exhaustive) list of how we plan to distribute raised funds:
+
+- **Swag!** Creating stickers, t-shirts, etc. for sponsors and community members.
+- **Improve documentation.**
+- **Improve translations.**
+- **Improve website.**
+- **User research.**
+- **Sponsoring conferences.**
+- **Sponsoring community members to represent Astro at meetups, conferences, etc.**
+- **Dedicated support for GitHub, Discord, Stack Overflow, etc.**
+
+## Eligibility
+
+**Employees of The Astro Technology Company are not eligible to receive funds from Open Collective.** These funds exist solely to serve the larger Astro community.

--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,0 +1,12 @@
+# These are supported funding model platforms
+
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: # Replace with a single Patreon username
+open_collective: astrodotbuild
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+otechie: # Replace with a single Otechie username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,463 @@
+# Governance
+
+This document outlines the governance model for Astro. This includes detailed descriptions of different roles, nomination processes, code review processes, and Code of Conduct enforcement.
+
+👉 **All community members must follow the [Code of Conduct (CoC)](CODE_OF_CONDUCT.md).**  
+Consequences for CoC violations are detailed in [Moderation](#moderation).
+
+👉 **Want to trigger a vote, nomination, or perform some other action?**  
+Scroll down to [Playbook](#governance-playbook).
+
+## Get Involved
+
+**Anything that supports the Astro community is a valuable contribution!**
+
+All types of contribution are meaningful. This can include code changes, type fixes, Discord activity, and even posting about Astro to your personal blog. No contribution is too small!
+
+Anyone can become an Astro contributor (yes, even you!). Engineering ability is not required. Our goal is to recognize all contributors to the project regardless of skill, experience or background.
+
+## Contributor Levels
+
+We recognize different levels of contribution as four different **Contributor Levels.** Because each level comes with a new set of privileges and responsibilities, you may also see these levels referred to as **Contributor Roles**.
+
+Contributor levels are available to **all members** of the Astro community, regardless of coding skill or experience.
+
+Two important things that we look for in a contributor are:
+
+- **Being here** - Everyone's time is valuable, and the fact that you're here and contributing to Astro is amazing! Thank you for being a part of this project with us.
+- **Being a positive member of our community** - Go above and beyond our [Code of Conduct](CODE_OF_CONDUCT.md) and commit to healthy communication across pull requests, issue discussions, Discord conversations, and any interactions outside of our community (ex: no Twitter bullies allowed :)
+
+All Contributor roles are granted for as long as the individual wishes to engage with the project.
+
+Contributors can voluntarily leave the project at any time. See [Retiring a Role](#retiring-a-role-alumni) below for more information.
+
+In extreme cases -- such as a Code of Conduct violation -- a role may be revoked by a project Steward at their discretion.
+
+Each new Contributor level unlocks new privileges and responsibilities both on Discord and on GitHub. Below is a summary of each level.
+
+### Level 1 - Contributor
+
+Have you done something (big or small) to contribute to the health, success, or growth of Astro? **Congratulations, you're officially recognized as a contributor to the project!**
+
+#### Examples of recognized contributions
+
+- **GitHub:** Submitting a merged pull request.
+- **GitHub:** Filing a detailed bug report or RFC.
+- **GitHub:** Updating documentation or fixing a typo.
+- Helping people on GitHub, Discord, etc.
+- Answering questions on Stack Overflow, Twitter, etc.
+- Blogging, Vlogging, Podcasting, and Livestreaming about Astro.
+- This list is incomplete! Similar contributions are also recognized.
+
+#### Privileges
+
+- New role on [Discord](https://astro.build/chat): `@contributor`
+- New name color on Discord: **light blue**.
+- Invitations to contributor-only events, sticker drops, and the occasional swag drop.
+
+#### Responsibilities
+
+This role does not require any extra responsibilities nor time commitment. We hope you stick around and keep participating in our community!
+
+If you're interested in reaching the next level and becoming a **Maintainer**, you can explore some of those responsibilities in the [next section](#level-2-l2---maintainer).
+
+#### Nomination Process
+
+You may self-nominate by sending the message `!contribute` in any Discord channel. If you do this, please share a second message with a link or description of your contribution so that people can recognize you for the contribution.
+
+You may also be granted this role automatically if you are active and helpful on Discord.
+
+### Level 2 (L2) - Maintainer
+
+The **Maintainer** role is available to contributors who want to join the team and take part in the long-term maintenance and growth of Astro.
+
+The Maintainer role is critical to the long-term health of Astro. Maintainers act as the first line of defense when it comes to new issues, pull requests and Discord activity. Maintainers are most likely the first people that a user will interact with on Discord or GitHub.
+
+**Maintainers are not required to write code!** Some Maintainers spend most of their time inside of Discord, maintaining a healthy community there. Others work on technical documentation, support, or design.
+
+**A Maintainer has moderation privileges!** All maintainers are trusted with the ability to help moderate our Discord and GitHub communities for things like spam. There is also a special (optional, opt-in) `@mods` role open to maintainers who are also interested in helping out when a community member reaches out for moderation help.
+
+#### Recognized Contributions
+
+There is no strict minimum number of contributions needed to reach this level, as long as you can show **sustained** involvement over some amount of time (at least a few months).
+
+- **GitHub:** Submitting multiple non-trivial pull requests and RFCs
+- **GitHub:** Reviewing multiple non-trivial pull requests and RFCs
+- **Discord:** Supporting users in Discord, especially in the #support channel
+- **Discord:** Active participation in RFC calls and other events
+- **GitHub + Discord:** Triaging and confirming user issues
+- This list is incomplete! Similar contributions are also recognized.
+
+#### Privileges
+
+- All privileges of the [Contributor role](#level-1---contributor), plus...
+- Invitation to the `@maintainer` role on [Discord](https://astro.build/chat)
+- Invitation to the private `#maintainers` channel on Discord.
+- Invitation to the `withastro` organization on GitHub.
+- Invitation to the `@maintainers` team on GitHub.
+- New name color on Discord: **blue**.
+- Ability to moderate Discord to remove spam, harmful speech, etc.
+- Ability to join the `@mods` role on Discord (optional, opt-in).
+- Ability to push branches directly to the `withastro` GitHub organization (personal forks no longer needed).
+- Ability to review GitHub PRs.
+- Ability to merge _some_ GitHub PRs.
+- Ability to vote on _some_ initiatives (see [Voting](#voting) below).
+
+#### Responsibilities
+
+- Participate in the project as a team player.
+- Bring a friendly, welcoming voice to the Astro community.
+- Be active on Discord, especially in the #support channel.
+- Triage new issues.
+- Review pull requests.
+- Merge some, non-trivial community pull requests.
+- Merge your own pull requests (once reviewed and approved).
+
+#### Nomination
+
+- To be nominated, a nominee is expected to already be performing some of the responsibilities of a Maintainer.
+- You can be nominated by any existing Maintainer (L2 or above).
+- Once nominated, there will be a vote by existing Maintainers.
+- See [vote rules & requirements](#voting) for info on how the vote works.
+
+### Level 3 (L3) - Core
+
+The **Core** role is available to community members who have a larger-than-usual impact on the Astro project and community. They are seen as leaders in the project and are listened to by the wider Astro community, often before they have even reached this level. A Core member is recognized for contributing a significant amount of time and energy to the project through issues, pull requests, bug fixes, implementing advanced enhancements/features, and/or actively posting on Discord.
+
+Not every contributor will reach this level, and that's okay! L2 Maintainers still have significant responsibility and privileges within our community.
+
+#### Privileges
+
+- All privileges of the [Maintainer role](#level-2---maintainer), plus...
+- `@core` role on [Discord](https://astro.build/chat)
+- New name color on Discord: **yellow**.
+- Invitation to the private `#core` channel on Discord.
+- Invitation to the `core` team on GitHub.
+- Ability to vote on most initiatives (see [Voting](#voting) below).
+
+#### Responsibilities
+
+- All of the responsibilities of L2, including...
+- Ownership over specific part(s) of the project.
+- Ownership over the long-term health and success of Astro.
+- Leadership as a role-model to other maintainers and community members.
+
+#### Nomination
+
+- To be nominated, a nominee is expected to already be performing some of the responsibilities of a Core member.
+- You can be nominated by any existing Core member (L3 or above).
+- Once nominated, there will be a vote by existing Core members.
+- See [vote rules & requirements](#voting) for info on how the vote works.
+
+#### Special Membership Type: Core Residency
+
+**Core Residency** is a special type of Core membership that is limited in the following way(s):
+
+- No voting abilities.
+- No nomination abilities.
+- Can be revoked at any time by the project Steward.
+
+Because of these limitations, this type of Core membership is useful for anyone who has been brought in to work on or contribute to the Astro project without rising through our normal contributor levels. For example: an Astro designer or developer advocate hired by The Astro Technology Company to assist the community could be nominated for a Core Residency role without having a previously earned contributor level.
+
+A Core Residency nomination must still be approved through the normal Core nomination and voting process. During the nomination, the Project Steward will state that the nomination is for the Core Residency designation. The project Steward is the only one who can officially make this designation during the nomination process.
+
+A Core Residency member can become a full Core member (with all limitations removed) through the normal Core nomination and voting procedure.
+
+If a Core Residency member has their membership revoked, the project Steward may choose to impose a waiting period of some number of days, during which the member can not be re-nominated to become a full Core member.
+
+### Level 4 - Project Steward
+
+The **Steward** is an additional role bestowed to 1 (or more) Core member of the project.
+
+The role of Steward is mainly an administrative one. Stewards control and maintain sensitive project assets, assist in resolving conflicts, and act as tiebreakers in the event of disagreements.
+
+In extremely rare cases, a Steward can act unilaterally when they believe it is in the project's best interest and can prove that the issue cannot be resolved through normal governance procedure. The steward must publicly state their reason for unilateral action before taking it.
+
+The project Steward is currently: **@FredKSchott**
+
+#### Responsibilities
+
+- Access to the [@astrodotbuild Twitter account](https://twitter.com/astrodotbuild)
+- Administration privileges on the [astro GitHub org](https://github.com/snowpackjs)
+- Administration privileges on the [astro Discord server](https://astro.build/chat)
+- Publish access to the [`astro` npm package](https://www.npmjs.com/package/astro)
+- Domain registrar and DNS access to `astro.build` and all other domains
+- Administration access to the `astro.build` Vercel account
+- Ability to initiate a [vote](GOVERNANCE.md#voting)
+- Ability to veto [votes](GOVERNANCE.md#voting) and resolve voting deadlocks
+- Define project direction and planning
+- Ability to decide on moderation decisions
+- Access to the `*@astro.build` email address
+
+#### Nomination
+
+- Stewards cannot be self-nominated.
+- Only Core members are eligible.
+- New Stewards will be added based on a unanimous vote by the existing Steward(s).
+- In the event that someone is unreachable then the decision will be deferred.
+
+## Other Roles
+
+### Project Teams
+
+Besides our contributor levels described above, there are additional roles and teams available that community members are welcome to join. Roles are a great way to organize around different projects and initiatives in our community. For example:
+
+- `@team-docs` runs the `#docs` channel and organizes the growth and development of Astro documentation.
+- `@i18n-gang` runs the `#docs-i18n` channel and organizes translations in several languages.
+- `@support-squad` runs the `#support-threads` channel and helps anyone who needs help using Astro.
+
+Many of these team roles can be browsed and joined automatically by visiting the `#manage-roles` channel in our Discord. Getting involved with a team is a great way to start contributing to Astro!
+
+### Moderator
+
+**Moderator** is a special role available to Maintainers (L2 and above). While all maintainers are granted permissions to moderate for bad behavior across our community, a Moderator actively takes on this the responsibility. For example, a community member may ping moderators (via the `@mods` role) to resolve spam posts or Code of Conduct violations.
+
+Trivial tasks (like removing spam) can be acted on unilaterally by a Moderator. Other non-trivial tasks (like assisting with or resolving a Code of Conduct violation) should involve the entire Moderator team (and in some cases, the project Steward).
+
+#### Privileges
+
+- `@mods` role on [Discord](https://astro.build/chat)
+- Invitation to the private `#moderators` channel on Discord
+- Invitation to the `staff` team on GitHub.
+
+#### Nomination
+
+Any Maintainer (L2 and above) can self-nominate by messaging the project Steward (`@steward`) on Discord.
+
+### Technical Steering Committee (TSC)
+
+The **TSC** is a special role available to Core members (L3 and above). TSC members are responsible for the growth and maintenance of the Astro codebase.
+
+TSC members are guardians over the Astro codebase. Their duty is to ensure code quality, correctness and security.
+
+A TSC member guides the direction of the project and ensures a healthy future for the Astro codebase. TSC members are ultimately responsible for technical decision making when it comes to any changes to the Astro codebase.
+
+A TSC member has significant sway in software design decisions. For this reason, coding experience is critical for this role. TSC membership is one of the only roles that requires a significant contribution history of code to the Astro project on GitHub.
+
+#### Privileges
+
+- `@tsc` role on [Discord](https://astro.build/chat)
+- Invitation to the private `#tsc` channel on Discord
+- Invitation to the `tsc` team on GitHub.
+- Ability to merge all GitHub PRs.
+- Ability to vote on RFCs and technical initiatives (see [Voting](#voting) below).
+
+#### Responsibilities
+
+- Participating in RFC discussions and technical meetings.
+- Assisting with design and implementation of non-trivial GitHub PRs.
+- Reviewing and merging larger, non-trivial PRs.
+- Maintaining and improving overall codebase architecture.
+- Tracking and ensuring progress of open pull requests.
+- Mentoring and guiding other community contributors.
+
+#### Nomination
+
+- To be nominated, a nominee is expected to already be active in technical discussions and performing some of the responsibilities of a TSC member.
+- You can be nominated by any existing Core member (L3 or above). Note: This includes all existing TSC members as well.
+- Once nominated, there will be a vote by existing Core members.
+- See [vote rules & requirements](#voting) for info on how this vote works.
+
+### Staff
+
+**Staff** is a special designation for employees of [The Astro Technology Company](https://astro.build/company).
+
+#### Privileges
+
+- `@staff` role on [Discord](https://astro.build/chat)
+- New name color on Discord: **yellow**.
+- Invitation to some private channels on Discord, at the discretion of the project Steward.
+- Invitation to the `staff` team on GitHub.
+
+Staff membership does not grant any additional abilities when it comes to voting and project governance. A Staff member is still eligible for other roles in the community and may still vote as defined by their other roles. For example, a Staff member who is also a part of `@core` will be able to vote as any other `@core` member would.
+
+### Alumni
+
+**Alumni** is a special designation for Maintainers (L2 and above) who have stepped away from the project and no longer contribute regularly. See [Retiring a Role](#retiring-a-role-alumni) below for more information.
+
+#### Privileges
+
+- `@alumni` role on [Discord](https://astro.build/chat)
+- New name color on Discord: **light blue**.
+- Invitation to the private `#alumni` channel on Discord.
+
+## Retiring a Role (Alumni)
+
+Contributor roles are granted for as long as the person wishes to engage with the project. However, over time an active community member may choose to step away from the Astro project to work on other things. Moving on from a project is a natural and well-understood part of any open source community, and we celebrate it!
+
+**Alumni** is a special designation and role for any person who was once an active maintainer (L2 or above) but is now no longer actively involved. By retiring and joining Alumni you trade-in your current set of roles, privileges, and responsibilities for a new, special Alumni role (which comes with its own set of Privileges, as described above).
+
+As a Maintainer (L2 or above) you can retire your role at any time by pinging the project Steward and requesting Alumni status. You can initiate this action yourself if you know ahead-of-time that you need to step away from the project. Or, if you have gone several months without interacting with the Astro community, the project Steward may actively reach out to you to discuss retiring as a way to make room for new contributors.
+
+As an Alumni member, you are still a part of the Astro community and can continue to be a part of our Discord, GitHub, and anywhere else. You may also request to have your old roles reinstated at any time through the normal nomination & voting process for that role.
+
+Rejoining the project as a contributor (L1 or above) will automatically remove you from the Alumni role.
+
+# Governance Playbook
+
+## Voting
+
+Certain project decisions (like governance changes and membership nominations) require a vote. Below are the changes that require a vote, and the rules that govern that vote.
+
+The project Steward may initiate a vote for any unlisted project decision. [General Rules](#general-rules) will apply, along with any addition rules provided at the steward's discretion. If this unlisted project decision is expected to be repeated in the future, voting rules should be agreed on and then added to this document.
+
+### General Voting Rules
+
+- Members may abstain from any vote.
+- Members who do not vote within 3 days will automatically abstain.
+- Stewards may reduce the 3 day automatic abstain for urgent decisions.
+- Stewards reserve the right to veto approval with a publicly disclosed reason.
+
+## Voting: Maintainer (L2) Nomination
+
+This process kicks off once a valid nomination has been made. See ["Maintainer - Nomination Process"](#nomination-process) above for more details on nomination.
+
+**Who can vote:** All Maintainers (L2 and above).
+
+1. A vote thread should be created in Discord #maintainers channel (the private channel for all maintainers).
+2. A vote thread can be created by any Maintainer, Core member, or the Steward.
+3. Once a vote thread is created, existing Maintainers can discuss the nomination in private.
+4. The normal 3 day voting & discussion window begins with the thread creation.
+5. Voting can be done in the thread (visible to other voters) or in a private DM to the project Steward.
+6. Once the vote is complete, the thread is deleted.
+7. The vote must receive an overwhelming majority (70%+) to pass.
+8. **If the vote passes:** the nominee will be made a Maintainer and all privileges will be made available to them.
+9. **If the vote fails:** the project Steward is responsible for informing the nominee with constructive, actionable feedback. (Note: this is not required if the nomination was made in the `#core` channel, or if the nominee was otherwise not made aware of their nomination).
+
+#### Draft message to send to accepted maintainer, informing them of the decision:
+
+```
+Hey ${NAME}!
+
+**I have some exciting news — you have been awarded the role of Maintainer (L2 Contributor) in the Astro community!**
+
+Some background: ${PERSON} nominated you for the role in the (private) #maintainers channel, and the consensus was overwhelmingly positive. Some quotes from the nomination thread that sum up the impact you've had so far:
+
+- ...
+- ...
+- ...
+
+We would be thrilled to have your help building the future of Astro. There is no required time commitment: you can continue to contribute as often or as little as you'd like. This is mainly a chance to recognize your contributions and give you more privileges in Discord and GitHub.
+
+Let me know if you’re interested in accepting this invitation. If so, we’ll start getting your roles up to date. And if you have any questions, feel free to let me know.
+
+Best,
+${MY_NAME}
+
+*PS: As a reminder, our Governance document describes the following privileges and responsibilities for the  **L2 - Maintainer** role: https://github.com/withastro/.github/blob/main/GOVERNANCE.md*
+```
+
+## Voting: Core Member (L3) Nomination
+
+This process kicks off once a valid nomination has been made. See ["Core Member - Nomination Process"](#nomination-process) above for more details on nomination.
+
+**Who can vote:** All Core members (L3 and above).
+
+1. A vote thread should be created in Discord `#core` channel (the private channel for Core members).
+2. A vote thread can be created by any Core member, or the Steward.
+3. Once a vote thread is created, existing Core members can discuss the nomination in private.
+4. The normal 3 day voting & discussion window begins with the thread creation.
+5. Voting can be done in the thread (visible to other voters) or in a private DM to the project Steward.
+6. Once the vote is complete, the thread is deleted.
+7. The vote must receive an overwhelming majority (70%+) to pass.
+8. **If the vote passes:** the nominee will be made a Core Member and all privileges will be made available to them.
+9. **If the vote fails:** the project Steward is responsible for informing the nominee with constructive, actionable feedback. (Note: this is not required if the nomination was made in the #core channel, or if the nominee was otherwise not made aware of their nomination).
+
+#### Draft message to send to accepted maintainer, informing them of the decision:
+
+```
+Hey $NAME!
+
+I have some exciting news—you’ve been nominated and accepted as a member of the Astro Core team! The Core team held a vote and overwhelmingly agree that you would be a great addition to the team. Congratulations! Thanks for all of your significant contributions to Astro to date and your continued dedication to this project and our community. We would be thrilled to have your help ensuring a healthy future for Astro!
+
+Please let me know if you’re interested in accepting this invitation. If so, we’ll start getting your roles and permissions up to date.
+
+As a reminder, our Governance document describes the following privileges and responsibilities for a **Core Member**:
+
+#### Privileges
+
+$COPY_AND_PASTE_FROM_ABOVE
+
+#### Responsibilities
+
+$COPY_AND_PASTE_FROM_ABOVE
+```
+
+## Voting: Governance Change
+
+A vote is initiated once a pull request to the GOVERNANCE.md file is submitted by a Core Member.
+
+If the pull request submitter is not a Core Member, the PR can be closed by any Maintainer without a vote. However, any Core Member may request a vote on that PR, in which case a vote is initiated.
+
+**Who can vote:** Core members (L3 and above). All Maintainers are encouraged to discuss and voice their opinion in the pull request discussion. Core members should take the opinions of Maintainers into consideration when voting.
+
+1. The pull request discussion thread is used to discuss the governance change.
+2. The normal 3 day voting & discussion window begins with either the PR creation or the removal of `WIP:` from the PR title if the PR was created as a draft.
+3. Voting can be done in the pull request via a review of either **Approve (For)** or **Change Requested (Against)**.
+4. The vote must receive a simple majority (50%+) to pass.
+5. **If the vote passes:** the PR is merged and the changes take effect immediately.
+6. **If the vote fails:** the PR is closed and no change occurs.
+
+## Voting: RFC Proposals
+
+Astro features are discussed using a model called [Consensus-seeking decision-making](https://en.wikipedia.org/wiki/Consensus-seeking_decision-making). This model attempts to achieve consensus on all significant changes to Astro, but has a fallback voting procedure in place if consensus appears unattainable.
+
+**Who can vote:** All [TSC](#technical-steering-committee-tsc) members.
+
+1. Anyone can submit an RFC to suggest changes to Astro.
+2. A trivial change can be discussed and approved entirely within the RFC GitHub issue, as long as there are no objections from Core or TSC members. This is not considered a formal vote.
+3. A non-trivial, significant change should be discussed within the RFC and approved during an RFC meeting call. In some cases, an RFC may be approved outside of an RFC meeting using Pull Request reviews as a proxy for votes.
+4. During an RFC meeting, the person leading the call will attempt to achieve consensus on the RFC proposal.
+5. **If consensus is reached:** the RFC is approved.
+6. **If consensus is not reached:** The RFC author and TSC members must make all reasonable attempts to resolve issues and reach consensus in GitHub or a follow-up RFC meeting. The process of reaching consensus can take time, and should not be rushed as long as all participants are making a reasonable effort to respond.
+7. **If consensus still cannot be reached:** The project Steward may invoke [rough consensus](https://en.wikipedia.org/wiki/Rough_consensus) to resolve an RFC that has not achieved absolute consensus, as described below (borrowed from the [IETF](https://datatracker.ietf.org/doc/html/rfc2418)):
+
+> Working groups make decisions through a "rough consensus" process. Astro consensus does not require that all participants agree although this is, of course, preferred. In general, the dominant view of the TSC shall prevail. (However, "dominance" is not to be determined on the basis of volume or persistence, but rather a more general sense of agreement). Consensus can be determined by a show of hands, humming, or any other means on which the TSC agrees (by rough consensus, of course). Note that 51% of the TSC does not qualify as "rough consensus" and 99% is better than rough. It is up to the project Steward to determine if rough consensus has been reached.
+
+## Moderation
+
+Outlined below is the process for Code of Conduct violation reviews.
+
+### Reporting
+
+Anyone may report a violation. Violations can be reported in the following ways:
+
+- In private, via email to one or more stewards.
+- In private, via direct message to a project steward on Discord.
+- In public, via a GitHub comment (mentioning `@snowpackjs/maintainers`).
+- In public, via the project Discord server (mentioning `staff`).
+
+### Who gets involved?
+
+Each report will be assigned reviewers. These will initially be all project [stewards](#stewards).
+
+In the event of any conflict of interest - ie. stewards who are personally connected to a situation, they must immediately recuse themselves.
+
+At request of the reporter and if deemed appropriate by the reviewers, another neutral third-party may be involved in the review and decision process.
+
+### Review
+
+If a report doesn’t contain enough information, the reviewers will strive to obtain all relevant data before acting.
+
+The reviewers will then review the incident and determine, to the best of their ability:
+
+- What happened.
+- Whether this event constitutes a Code of Conduct violation.
+- Who, if anyone, was involved in the violation.
+- Whether this is an ongoing situation.
+
+The reviewers should aim to have a resolution agreed very rapidly; if not agreed within a week, they will inform the parties of the planned date.
+
+### Resolution
+
+Responses will be determined by the reviewers on the basis of the information gathered and of the potential consequences. It may include:
+
+- taking no further action
+- issuing a reprimand (private or public)
+- asking for an apology (private or public)
+- permanent ban from the GitHub org and Discord server
+- revoked contributor status
+
+---
+
+Inspired by [ESLint](https://eslint.org/docs/6.0.0/maintainer-guide/governance), [Rome](https://github.com/rome/tools/blob/main/GOVERNANCE.md) and [Blitz](https://blitzjs.com/docs/maintainers).


### PR DESCRIPTION
This PR copies over community health files from `withastro/astro` so that they apply to all repos across the GitHub org.

I’ve left `CONTRIBUTING.md` and `STYLE_GUIDE.md` in place as those are repo-specific, but:

- Language Tools and the Prettier plugin do also link to the style guide, so we coud also move that if people prefer?
- In the future, we could consider an org-wide `CONTRIBUTING.md` at some point if we think there are common things we want to ensure show up in all repos.