### PR TITLE
add maintainer nomination docs

### DIFF
--- a/maintainer-nomination-docs/discord-message-template.md
+++ b/maintainer-nomination-docs/discord-message-template.md
@@ -1,0 +1,42 @@
+# Nomination post template
+
+## Thread Title: {Discord/GitHub name} nomination thread
+
+### Discord Name: {@username} / GitHub Name: {@username}
+
+### Astro Badge: https://astro.badg.es/v1/contributor/{github-username}
+
+### Contributions:
+*(Include any/all sections below as appropriate. No particular section or item listed is required, but remember, not all maintainers will be familiar with your nominee! The items below will help you present the nominee's contributions to maintainers who might not know them.)*
+
+**Code Contributions (all repos, including docs):**
+- mention recent or outstanding PRs, helpful review comments, active discussions in the #dev Discord channel
+- include links to: PRs, review comments showing helpful feedback on others' PRs
+- point out any particularly valuable themes/areas of contribution, especially if the person has carved out a niche and started to "own" an area of the codebase. (e.g. i18n, a11y, translations, docs writing, tests, an integration)
+
+**Support/Community:**
+- describe general or specific helpful Discord activity you have noticed
+- include quotes of helpful comments, links to Discord threads
+- mention how they have contributed to the "vibe" in Discord and/or how they would make a good moderator (since maintainers may self-select as mods)
+
+**Representation outside of our Community:**
+- mention ways in which the nominee currently represents Astro positive outside our community on social media: Tweets, engagement with the official Astro accounts
+- highlight any community meetups, conference talks promoting Astro
+- mention any personal blog posts or videos that promote Astro. (e.g. video courses, live streams of working on Astro, blog posts describing how to build with Astro)
+
+### Personal Endorsement message:
+
+Use this space to write a personal message in support of the nominee becoming maintainer and your reasons for nominating. What would you like voters to know about the nominee that perhaps they don't and isn't adequately captured above?
+
+### Your Responsibility as a Voter:
+*(Please include this section as written, in its entirety)*
+
+Please reply to this thread with a clear vote within three days: yes, no, or abstain. Not voting within three days is equivalent to abstaining.
+
+If voting yes, please include a comment or elaboration if possible. Our community is large and others may not know the nominee very well, so knowing that other maintainers approve can instill confidence in a voter who has not interacted with the nominee very much. Some of these comments will also be included (anonymously) in the message sent to successful nominees as "Here are some things people said about you", so it is helpful to have some positive comments to include and make the message that much more personal!
+
+If voting no, a reason is not required, but please do mention any strong reservations you might have about the nominee. If you have reason to believe that there would be serious problems with this person having access to the repositories, moderation powers, or being seen as an authority figure on Discord or a public representative of Astro, then please voice these concerns. These concerns may be shared (anonymously) with the nominee if the vote passes.
+
+If abstaining, no reason is required. You are still free to share any thoughts (positive or negative) about the nomination, and these may be included (anonymously) in the nominee's congratulation message.
+
+cc `@maintainers` (or `@core` as appropriate)

--- a/maintainer-nomination-docs/guide-to-nominating-a-new-maintainer.md
+++ b/maintainer-nomination-docs/guide-to-nominating-a-new-maintainer.md
@@ -1,0 +1,49 @@
+# So you want to nominate a maintainer...
+
+One of the responsibilities of being an Astro Maintainer (L2 or L3) is to **watch for and recognize outstanding contributions from the community** and nominate community members as new maintainers when appropriate.
+
+
+New maintainer candidates may distinguish themselves by already acting *like* a maintainer with their helpful involvement. It is your responsibility to be on the lookout for community members who:
+- are active GitHub contributors, either through submitting PRs to any of the `withastro` repos, filing and participating in Issues, or adding helpful review comments to existing PRs.
+- are active in the Astro Discord server: welcoming new members, answering support questions, commenting on others' showcase submissions, or generally interacting with the community in a way consistent with being a maintainer.
+
+We have had excellent candidates go unnoticed because people assumed they were already a maintainer. This means that active members of our community go unrecognized, and we have fewer people available to perform routine maintenance tasks like approving and merging PRs. 
+
+When you are ready to nominate a new maintainer, follow the 
+[nomination process](https://github.com/withastro/.github/blob/main/GOVERNANCE.md#governance-playbook) as described in our governance document. It is not required to tell the candidate you are nominating them. In most cases, the candidate is unaware that they are being considered.
+
+While this process is straightforward in outlining *what* will happen, it does not explicitly state *who* is responsible for ensuring that the steps are taken.
+
+## Responsibilities
+
+Specifically, the nomination process requires action from:
+- the nominator: an existing Astro maintainer (L2 or L3-core)
+- the core shepherd: an existing L3-core maintainer
+- the project Steward
+
+**Note** - One person can assume multiple roles. For example, if the nominator is an existing L3 maintainer, then it is assumed they will also act as the core shepherd. The project Steward may assume all three roles.
+
+## Nominator
+
+The nominator will:
+- create a Discord thread and make an initial post (see Post Template) to initiate the nomination process, ensuring that the channel members have been mentioned to add them to the thread.
+- seek out a core shepherd (any willing L3 core maintainer with access to Astro's task board in Linear) to oversee the execution of all the nomination steps. The core shepherd will add the nomination process task template to their current sprint cycle in Linear, and will be responsible for ensuring that all tasks are completed. Note: If the nominator is an existing L3-core maintainer with access to Linear, then it is assumed that the nominator will also act as the core shepherd. 
+- respond to questions or comments made by other maintainers in the thread
+- Post a reminder in the thread when one day of voting remains.
+- Post in the thread mentioning the project Steward when voting has expired, with a tally of yes, no, abstain votes made in the thread. (Note: it is normal for some maintainers to not vote and to automatically abstain. These need not be counted in this post. The project Steward will consider the entire maintainership as a whole when interpreting the results.)
+- Collect some positive comments about the candidate made in the thread to be used in the acceptance message, if the vote passes. It is important to collect these outside of the thread as this thread will be deleted. If the vote passes, DM these to the project Steward for use in the maintainers invitation message that will be sent.
+
+The core shepherd will:
+- Add the "Maintainer Nomination" task template to their current sprint cycle in Linear. (Note that this template also includes tasks pre-assigned to the Project Steward.)
+- Ensure that each task in the template is completed, in a timely fashion. Note: some of these tasks are simply to ensure/confirm that tasks have been completed by the Project Steward (i.e. nothing slips through the cracks), and not necessarily to complete these tasks themselves.
+- Answer any questions the nominator may have, and generally assist if the nominator or Project Steward has any difficulties executing their responsibilities.
+- Act as a liaison between the nominator and the Project Steward, as necessary.
+
+The Project Steward will:
+- Inform the nominator of any problems with the nomination upon noticing that the nomination process has been initiated. (i.e. if there is some reason why this nomination cannot proceed)
+- Upon noticing the post specifiying that the voting period has completed with the vote tally, will interpret the results of the vote, including abstaining members, as described in the governance document.
+- make a final post in the thread confirming the outcome of the vote.
+- use the "Maintainer invitation" template to send a private Discord message to an accepted candidate, including the quotes collected by the nominator.
+- delete the nomination thread upon receiving an answer from the candidate
+- upon receiving acceptance from the candidate, update the new maintainer's Discord role and GitHub permissions.
+- ask the nominator whether they would like to post a congratulatory message on Discord themselves, or whether they would like the project Steward to do so on their behalf.


### PR DESCRIPTION
This adds two documents to the repo:

1. A guide to follow for nominating a new maintainer, with steps/responsibilities for each person involved.
2. A Discord message template to assist the nominator in crafting a nomination message.

Since the governance documents are in this repo, and there's no reason for these documents to be private, I figured this would be a good place to put them!