### PR TITLE
Mention `alumni` GitHub team in governance docs

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -280,6 +280,7 @@ Staff membership does not grant any additional abilities when it comes to voting
 - `@alumni` role on [Discord](https://astro.build/chat)
 - New name color on Discord: **light blue**.
 - Invitation to the private `#alumni` channel on Discord.
+- Invitation to the `alumni` team on GitHub.
 
 ## Retiring a Role (Alumni)
 


### PR DESCRIPTION
Updates our alumni section of the governance docs to mention the associated GitHub team.