### PR TITLE
Update Discord post for maintainer nomination to refer to "poll" feature

### DIFF
--- a/maintainer-nomination-docs/discord-message-template.md
+++ b/maintainer-nomination-docs/discord-message-template.md
@@ -31,12 +31,15 @@ Use this space to write a personal message in support of the nominee becoming ma
 ### Your Responsibility as a Voter:
 *(Please include this section as written, in its entirety)*
 
-Please reply to this thread with a clear vote within three days: yes, no, or abstain. Not voting within three days is equivalent to abstaining.
+**Your Responsibility as a Voter:**
+Please vote in the poll on or before [3 business days in the future]. Not voting within this period is equivalent to abstaining.
 
-If voting yes, please include a comment or elaboration if possible. Our community is large and others may not know the nominee very well, so knowing that other maintainers approve can instill confidence in a voter who has not interacted with the nominee very much. Some of these comments will also be included (anonymously) in the message sent to successful nominees as "Here are some things people said about you", so it is helpful to have some positive comments to include and make the message that much more personal!
+**If voting yes**, please include a comment or elaboration if possible. Our community is large and others may not know the nominee very well, so knowing that other maintainers approve can help voters who have not interacted with the nominee very much. Some of these comments will also be included (anonymously) in the message sent to successful nominees as "Here are some things people said about you", so it is helpful to have some positive comments to include and make the message that much more personal!
 
-If voting no, a reason is not required, but please do mention any strong reservations you might have about the nominee. If you have reason to believe that there would be serious problems with this person having access to the repositories, moderation powers, or being seen as an authority figure on Discord or a public representative of Astro, then please voice these concerns. These concerns may be shared (anonymously) with the nominee if the vote passes.
+**If voting no**, a reason is not required, but please do mention any strong reservations you might have about the nominee. If you have reason to believe that there would be serious problems with this person having access to the repositories, moderation powers, or being seen as an authority figure on Discord or a public representative of Astro, then please voice these concerns. These concerns may be shared (anonymously) with the nominee if the vote passes.
 
 If abstaining, no reason is required. You are still free to share any thoughts (positive or negative) about the nomination, and these may be included (anonymously) in the nominee's congratulation message.
+
+**Before abstaining**, please remember it is your responsibility as a maintainer to help vet potential new maintainers. Just because you don't know them *now* doesn't mean that you must abstain! A quick investigation (following the above links, searching their posts on Discord, etc.) might lead to either enough information for you to vote yes, or to some concerns that will be helpful to this conversation. Even if abstaining, you may have helpful contributions to this process.
 
 cc `@maintainers` (or `@core` as appropriate)

--- a/maintainer-nomination-docs/discord-message-template.md
+++ b/maintainer-nomination-docs/discord-message-template.md
@@ -31,7 +31,6 @@ Use this space to write a personal message in support of the nominee becoming ma
 ### Your Responsibility as a Voter:
 *(Please include this section as written, in its entirety)*
 
-**Your Responsibility as a Voter:**
 Please vote in the poll on or before [3 business days in the future]. Not voting within this period is equivalent to abstaining.
 
 **If voting yes**, please include a comment or elaboration if possible. Our community is large and others may not know the nominee very well, so knowing that other maintainers approve can help voters who have not interacted with the nominee very much. Some of these comments will also be included (anonymously) in the message sent to successful nominees as "Here are some things people said about you", so it is helpful to have some positive comments to include and make the message that much more personal!

--- a/maintainer-nomination-docs/discord-message-template.md
+++ b/maintainer-nomination-docs/discord-message-template.md
@@ -31,7 +31,7 @@ Use this space to write a personal message in support of the nominee becoming ma
 ### Your Responsibility as a Voter:
 *(Please include this section as written, in its entirety)*
 
-Please vote in the poll on or before [3 business days in the future]. Not voting within this period is equivalent to abstaining.
+Please vote in the poll within 3 business days. Not voting within this period is equivalent to abstaining.
 
 **If voting yes**, please include a comment or elaboration if possible. Our community is large and others may not know the nominee very well, so knowing that other maintainers approve can help voters who have not interacted with the nominee very much. Some of these comments will also be included (anonymously) in the message sent to successful nominees as "Here are some things people said about you", so it is helpful to have some positive comments to include and make the message that much more personal!
 


### PR DESCRIPTION
Updating the reference Discord post template for nominating a maintainer because now we ask people to vote in a Discord poll.

Also adds minor formatting/language edits. 

Also includes a new section "Before abstaining" -- reminding maintainers that it is their responsibility to participate in the process even if they do not know the nominee, and suggesting how they can contribute to the discussion.