### PR TITLE
Fix broken link to `GOVERNANCE.md` (rome/tools)

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -418,4 +418,4 @@ Responses will be determined by the reviewers on the basis of the information ga
 
 ---
 
-Inspired by [ESLint](https://eslint.org/docs/6.0.0/maintainer-guide/governance), [Rome](https://github.com/rome/tools/blob/main/GOVERNANCE.md) and [Blitz](https://blitzjs.com/docs/maintainers).
+Inspired by [ESLint](https://eslint.org/docs/6.0.0/maintainer-guide/governance), [Rome](https://github.com/rome/tools/blob/203b8efaf3ff087e82b97c484dedc5b5c5f15bcd/GOVERNANCE.md) and [Blitz](https://blitzjs.com/docs/maintainers).


### PR DESCRIPTION
The link to the `GOVERNANCE.md` from the [`rome/toosls`]() repo is broken, because it got remoted in https://github.com/rome/tools/commit/450e109f202b08aba3203ef02b5d88fad5e0ff3a (see [history of `GOVERNANCE.md` file](https://github.com/rome/tools/commits/main/GOVERNANCE.md)).

Maybe linking to the last version before it got deleted is more appropriate: https://github.com/rome/tools/blob/203b8efaf3ff087e82b97c484dedc5b5c5f15bcd/GOVERNANCE.md

If anyone has suggestions, pls let me know!

Btw, I'm not sure if all the Discord roles mentioned still exist (eg. `@i18n-gang` got renamed to `@i18n-crew`, ...). Maybe I'll take a look at it, but tbh I'm kinda too lazy now...