### PR TITLE
WIP: Specify limits of TSC membership

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -234,6 +234,8 @@ A TSC member guides the direction of the project and ensures a healthy future fo
 
 A TSC member has significant sway in software design decisions. For this reason, coding experience is critical for this role. TSC membership is one of the only roles that requires a significant contribution history of code to the Astro project on GitHub.
 
+The TSC is limited to a maximum of __5__ members at any one time. This size ensures adequate coverage of important areas of expertise balanced with the ability to make decisions efficiently.
+
 #### Privileges
 
 - `@tsc` role on [Discord](https://astro.build/chat)


### PR DESCRIPTION
This change specifies a limit of 5 members of TSC at any one time.

This was originally included in #48 but was removed to prevent blocking the rest of the PR which was more focused on the RFC process.

I want to champion this change because we are looking to expand the TSC outside of the 2 current members, but have learned from other organizations (Node.js and ESLint in particular) that having a small TSC is helpful to keep things moving quickly.