### PR TITLE
Update TSC membership rules

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -234,7 +234,7 @@ A TSC member guides the direction of the project and ensures a healthy future fo
 
 A TSC member has significant sway in software design decisions. For this reason, coding experience is critical for this role. TSC membership is one of the only roles that requires a significant contribution history of code to the Astro project on GitHub.
 
-The Steward is not eligible for the TSC, but may participate in TSC discussions and has a role in guiding the conversation to consensus (see [Voting: RFC Proposals]([https://github.com/withastro/.github/blob/main/GOVERNANCE.md#technical-steering-committee-tsc](https://github.com/withastro/.github/blob/main/GOVERNANCE.md#voting-rfc-proposals)).
+The Steward is not eligible for the TSC, but may participate in TSC discussions and has a role in guiding the conversation to consensus (see [Voting: RFC Proposals](#voting-rfc-proposals)).
 
 #### Privileges
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -234,6 +234,8 @@ A TSC member guides the direction of the project and ensures a healthy future fo
 
 A TSC member has significant sway in software design decisions. For this reason, coding experience is critical for this role. TSC membership is one of the only roles that requires a significant contribution history of code to the Astro project on GitHub.
 
+The Steward is not eligible for the TSC, but may participate in TSC discussions and has a role in guiding the conversation to consensus (see [Voting: RFC Proposals]([https://github.com/withastro/.github/blob/main/GOVERNANCE.md#technical-steering-committee-tsc](https://github.com/withastro/.github/blob/main/GOVERNANCE.md#voting-rfc-proposals)).
+
 #### Privileges
 
 - `@tsc` role on [Discord](https://astro.build/chat)
@@ -253,10 +255,9 @@ A TSC member has significant sway in software design decisions. For this reason,
 
 #### Nomination
 
-- To be nominated, a nominee is expected to already be active in technical discussions and performing some of the responsibilities of a TSC member.
-- You can be nominated by any existing Core member (L3 or above). Note: This includes all existing TSC members as well.
-- Once nominated, there will be a vote by existing Core members.
-- See [vote rules & requirements](#voting) for info on how this vote works.
+- The makeup of the TSC is decided by the project Steward.
+- A core member may self-nominate by sending a private message to the Steward. The Steward shall provide time and effort to discuss the nomination with any nominee, and provide feedback that would be helpful to the nominee as they evaluate their own nomination.
+- The Steward must communicate all TSC membership changes in the Discord `#core` channel (the private channel for Core members).
 
 ### Staff
 


### PR DESCRIPTION
This is proposed as an alternative to https://github.com/withastro/.github/pull/52 based on feedback I've received from potential TSC members after https://github.com/withastro/.github/pull/48 was merged. It is complementary to https://github.com/withastro/.github/pull/51 and not blocking that discussion.

So I'd actually thought that the TSC makeup was ultimately decided by the project steward, and only after #48 was merged did I realize that there is a nomination + voting process. I wasn't planning on revisiting this until after the TSC had been updated through the now-unblocked self-nomination process, but based on feedback from people trying to go through the process now, it sounds like the current process is still flawed. 

I'd like to remove the nomination process and move to a simpler model for a couple of reasons:
- Efficiency: Every Core Maintainer has already gone through a nomination and 3-day Core Maintainer vetting/voting process. With very rare exceptions, I believe anyone who meets the stricter eligibility requirements re: code contributions (as outlined) would by definition make a great TSC member. Therefore, the extra secondary voting process feels like it is not worth the time and energy required to reevaluate each core member individually for TSC.
- Difficulty: There's been feedback that self-nomination is impossible since you can't create a thread that you don't have access to, which is the normal process for people-related voting. #52 was created to solve for this as a specific problem, but in this PR I wanted to explore solving the problem by removing the problem.
- Flexibility & Alignment: Our governance already relies on the notion of trusting the Steward to guide the project, and my trust in the Steward -- whoever that might be, me today, someone else tomorrow -- would naturally extend to trusting them to choose a TSC body that reflects the goals and values of the project. 
- Risk of Stagnation: Currently, there are possible situations where a TSC member might drift away from the project but still want to participate in the TSC in a way that doesn't align with the values or goals of the active core members. This was a problem that Nicholas Zakas faced in his TSC makeup (referenced in #48 and #51) that I'd love to avoid if possible. Another risk is that we hit the 5 person max and then rarely does anyone want to leave. I'd prefer to remove the legacy bias and have a TSC made up of the 5 best people vs. the 5 people who got there first in 2025 (avoiding unnecessary thrash ofc).

Notably, this PR also removes me from the TSC, since the project steward has enough power as it is and is still responsible to be an engaged guide/participant alongside the TSC in RFC discussions.