### PR TITLE
Better frame responsibilities

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -138,9 +138,9 @@ Not every contributor will reach this level, and that's okay! L2 Maintainers sti
 #### Responsibilities
 
 - All of the responsibilities of L2, including...
-- Ownership over specific part(s) of the project.
-- Ownership over the long-term health and success of Astro.
-- Leadership as a role-model to other maintainers and community members.
+- Own specific part(s) of the project.
+- Own the long-term health and success of Astro.
+- Act as a role-model to other maintainers and community members.
 
 #### Nomination
 
@@ -177,11 +177,9 @@ The project Steward is currently: **@FredKSchott**
 
 #### Responsibilities
 
-- Ability to initiate a [vote](GOVERNANCE.md#voting)
-- Ability to veto [votes](GOVERNANCE.md#voting) and resolve voting deadlocks
-- Define project direction and planning
-- Ability to decide on moderation decisions
-- Create, administer, and manage access to all third-party services/accounts to which the project has access
+- Create, administer, and manage access to all third-party services/accounts to which the project has access.
+- Ensure [voting](#voting) is carried out according to governance, resolve deadlocks, and veto the result of a vote in extreme situations when deemed necessary for the sake of the project.
+- Oversee moderation of community spaces such as GitHub and Discord, resolve deadlocks, enforce the decisions of moderators when necessary.
 
 #### Nomination
 
@@ -243,12 +241,12 @@ The Steward is not eligible for the TSC, but may participate in TSC discussions 
 
 #### Responsibilities
 
-- Participating in RFC discussions and technical meetings.
-- Assisting with design and implementation of non-trivial GitHub PRs.
-- Reviewing and merging larger, non-trivial PRs.
-- Maintaining and improving overall codebase architecture.
-- Tracking and ensuring progress of open pull requests.
-- Mentoring and guiding other community contributors.
+- Participate in RFC discussions and technical meetings.
+- Assist with design and implementation of non-trivial GitHub PRs.
+- Review and merge larger, non-trivial PRs.
+- Maintain and improve overall codebase architecture.
+- Track and ensure progress of open pull requests.
+- Mentor and guide other community contributors.
 
 #### Nomination
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -177,6 +177,7 @@ The project Steward is currently: **@FredKSchott**
 
 #### Responsibilities
 
+- Define project direction and planning
 - Create, administer, and manage access to all third-party services/accounts to which the project has access.
 - Ensure [voting](#voting) is carried out according to governance, resolve deadlocks, and veto the result of a vote in extreme situations when deemed necessary for the sake of the project.
 - Oversee moderation of community spaces such as GitHub and Discord, provide guidance, and enforce the decisions of moderators when necessary.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -179,7 +179,7 @@ The project Steward is currently: **@FredKSchott**
 
 - Define project direction and planning
 - Create, administer, and manage access to all third-party services/accounts to which the project has access.
-- Ensure [voting](#voting) is carried out according to governance, resolve deadlocks, and veto the result of a vote in extreme situations when deemed necessary for the sake of the project.
+- Ensure voting is carried out according to governance. See [Voting](#voting) below.
 - Oversee moderation of community spaces such as GitHub and Discord, provide guidance, and enforce the decisions of moderators when necessary.
 
 #### Nomination

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -177,17 +177,12 @@ The project Steward is currently: **@FredKSchott**
 
 #### Responsibilities
 
-- Access to the [@astrodotbuild Twitter account](https://twitter.com/astrodotbuild)
-- Administration privileges on the [astro GitHub org](https://github.com/withastro)
 - Administration privileges on the [astro Discord server](https://astro.build/chat)
-- Publish access to the [`astro` npm package](https://www.npmjs.com/package/astro)
 - Domain registrar and DNS access to `astro.build` and all other domains
-- Administration access to the `astro.build` Vercel account
 - Ability to initiate a [vote](GOVERNANCE.md#voting)
 - Ability to veto [votes](GOVERNANCE.md#voting) and resolve voting deadlocks
 - Define project direction and planning
 - Ability to decide on moderation decisions
-- Access to the `*@astro.build` email address
 
 #### Nomination
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -178,7 +178,6 @@ The project Steward is currently: **@FredKSchott**
 #### Responsibilities
 
 - Administration privileges on the [astro Discord server](https://astro.build/chat)
-- Domain registrar and DNS access to `astro.build` and all other domains
 - Ability to initiate a [vote](GOVERNANCE.md#voting)
 - Ability to veto [votes](GOVERNANCE.md#voting) and resolve voting deadlocks
 - Define project direction and planning

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -179,7 +179,7 @@ The project Steward is currently: **@FredKSchott**
 
 - Create, administer, and manage access to all third-party services/accounts to which the project has access.
 - Ensure [voting](#voting) is carried out according to governance, resolve deadlocks, and veto the result of a vote in extreme situations when deemed necessary for the sake of the project.
-- Oversee moderation of community spaces such as GitHub and Discord, resolve deadlocks, enforce the decisions of moderators when necessary.
+- Oversee moderation of community spaces such as GitHub and Discord, provide guidance, and enforce the decisions of moderators when necessary.
 
 #### Nomination
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -177,7 +177,6 @@ The project Steward is currently: **@FredKSchott**
 
 #### Responsibilities
 
-- Administration privileges on the [astro Discord server](https://astro.build/chat)
 - Ability to initiate a [vote](GOVERNANCE.md#voting)
 - Ability to veto [votes](GOVERNANCE.md#voting) and resolve voting deadlocks
 - Define project direction and planning

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -180,7 +180,7 @@ The project Steward is currently: **@FredKSchott**
 - Define project direction and planning
 - Create, administer, and manage access to all third-party services/accounts to which the project has access.
 - Ensure voting is carried out according to governance. See [Voting](#voting) below.
-- Assisst with moderation. See [Moderation](#moderation) below.
+- Assist with moderation. See [Moderation](#moderation) below.
 
 #### Nomination
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -180,7 +180,7 @@ The project Steward is currently: **@FredKSchott**
 - Define project direction and planning
 - Create, administer, and manage access to all third-party services/accounts to which the project has access.
 - Ensure voting is carried out according to governance. See [Voting](#voting) below.
-- Oversee moderation of community spaces such as GitHub and Discord, provide guidance, and enforce the decisions of moderators when necessary.
+- Assisst with moderation. See [Moderation](#moderation) below.
 
 #### Nomination
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -181,7 +181,7 @@ The project Steward is currently: **@FredKSchott**
 - Ability to veto [votes](GOVERNANCE.md#voting) and resolve voting deadlocks
 - Define project direction and planning
 - Ability to decide on moderation decisions
-- Create, administer, and manage access to all third-party services/accounts to which Astro has access
+- Create, administer, and manage access to all third-party services/accounts to which the project has access
 
 #### Nomination
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -180,7 +180,7 @@ The project Steward is currently: **@FredKSchott**
 - Define project direction and planning
 - Create, administer, and manage access to all third-party services/accounts to which the project has access.
 - Ensure voting is carried out according to governance. See [Voting](#voting) below.
-- Assist with moderation. See [Moderation](#moderation) below.
+- Oversee moderation of community spaces such as GitHub and Discord. See [Moderation](#moderation) below.
 
 #### Nomination
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -181,6 +181,7 @@ The project Steward is currently: **@FredKSchott**
 - Ability to veto [votes](GOVERNANCE.md#voting) and resolve voting deadlocks
 - Define project direction and planning
 - Ability to decide on moderation decisions
+- Create, administer, and manage access to all third-party services/accounts to which Astro has access
 
 #### Nomination
 


### PR DESCRIPTION
END OF VOTE: 2025/02/04 2:56 PM CET

- Updates L2 and TSC responsibilities to be framed as reponsibilities (ie. update verbs)
- Updates the Project Steward responsibilities to actually be framed as responsibilities, not rights/privileges
	- Although the Project Steward responsibilities section may looks like it contain less things, it is not the case!
	- It rephrases responsibilities to be clearer, and incorporates how/when to use some of these specific rights (eg. "veto for emergencies")
	- This also allow to clarify how services are managed, since the governance did not reflect reality (see #65 comments): eg. L3 members having admin rights over the GH org.

So to be clear, no right is removed!